### PR TITLE
Remove download folder permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+repo/

--- a/org.beagleboard.imagingutility.yaml
+++ b/org.beagleboard.imagingutility.yaml
@@ -14,7 +14,6 @@ build-options:
 finish-args:
   - --share=ipc
   - --share=network
-  - --filesystem=xdg-download
   - --socket=wayland
   - --socket=fallback-x11
   # SD Card permissions


### PR DESCRIPTION
- Since rfd uses portals, no need for permission to filesystem